### PR TITLE
#4 YAML parsing failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
         "fuse.js": "^7.1.0",
         "ical-generator": "^10.0.0",
@@ -5241,6 +5242,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/code-block-writer": {


### PR DESCRIPTION
Fixes #4

## Summary

This PR replaces silent YAML failure handling with strict validation during static generation. Instead of quietly excluding invalid program files, the build now fails with clear diagnostics that identify the exact schema or syntax violation.

The goal is to remove hidden data issues, improve contributor feedback, and enforce consistent program configuration quality across the repository.

---

## Background

Previously, the `getPrograms` loader swallowed exceptions while parsing program YAML files. When malformed syntax or missing schema fields were encountered, the function returned `null`, which caused the affected program to be silently filtered out during static generation.

Common failure cases included:

* Missing required nested fields such as `stipend.available`
* Invalid array structures or malformed objects
* Typographical mistakes inside `dates` or similar nested properties
* YAML parse errors caused by invalid indentation or formatting

Because errors were suppressed, contributors often saw their program disappear from preview builds without any indication of what went wrong. This created unnecessary review friction and required maintainers to manually debug contributor submissions.

---

## What Changed

### 1. Strict Failure Boundaries

Silent filtering has been removed.
If any file inside `data/programs/` is invalid, `next build` now exits with a failure status. Static generation will not proceed with partially valid data.

### 2. Explicit Syntax vs Schema Separation

Parsing errors and validation errors are handled independently:

* **YAML Syntax Errors**
  Triggered by `js-yaml` when the file itself is structurally invalid.

* **Schema Validation Errors**
  Triggered by Zod when data violates required shape or type constraints.

This separation makes logs easier to reason about during CI failures.

### 3. Structured Terminal Diagnostics

Zod errors are transformed into readable output with ANSI formatting to improve clarity inside local terminals, Vercel logs, and GitHub Actions.

Each error now prints:

* The exact filename causing the failure
* A dot-path reference to the invalid property
  (example: `dates.0.program_start`)
* The explicit validation rule that failed
  (example: `Expected boolean, received string`)

---

## Before vs After

### Before

* Invalid YAML silently ignored
* Programs disappeared from builds
* Contributors had no debugging signal
* Maintainers needed to manually inspect files

### After

* Build fails immediately on invalid configuration
* Clear error messages in CI logs
* Contributors can fix issues without maintainer intervention
* Static data integrity enforced at build time

---

## Example Error Output

Invalid program YAML: `ai-fellowship.yaml`

Path: `dates.0.program_start`
Issue: Expected boolean, received string

ZodError:

* stipend.available: expected boolean, received undefined
* category: expected string, received undefined
* tags: invalid option, expected one of ["mentorship","grant","fellowship","hackathon","internship"]

---

## Impact

This introduces stricter validation behavior during static builds.

CI/CD pipelines on Vercel and GitHub Actions will now fail early when malformed program files are introduced. Instead of silently dropping data, contributors receive actionable feedback directly from build logs.

This improves long-term data hygiene and reduces review overhead.

---

##  Breaking Behaviour

Builds will now fail if *any* program YAML file is invalid.
This is intentional and ensures the repository maintains a consistent schema across all program entries.

---

## How to Test

1. Introduce an invalid field inside any YAML file under `data/programs/`

2. Run:

   npm run build

3. Confirm that:

   * The build exits with an error
   * The terminal shows a filename, property path, and validation message

---

## Notes

No runtime UI behavior was changed.
All updates are confined to static generation and data validation logic.


After my solution how will error look like
<img width="1234" height="262" alt="image" src="https://github.com/user-attachments/assets/4660849a-edd3-4712-9cb1-9f780418fec1" />
