### PR TITLE
Fix link to GitHub Security Advisories feature

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,7 +16,7 @@ We take the security of this project seriously. If you discover a security vulne
 
 Instead, please:
 
-1. Open a security advisory on GitHub using the [Security Advisories](https://github.com/OWASP-STUDENT-CHAPTER/oss-programs/security/advisories/new) feature
+1. Open a security advisory on GitHub using the [Security Advisories](https://github.com/OWASP-STUDENT-CHAPTER/oss-programs/security) feature
 2. Or email the maintainers directly with details about the vulnerability
 
 Please include:


### PR DESCRIPTION
---
Fixes #19 
name: Pull Request
about:Fixed the link to Security Advisories
title: ''
labels: ''
assignees: ''
---

## Description

The documentation change is a "fallback" to prevent the 404, but the primary fix requires them to enable the feature in their settings.

## Type of Change

- [*] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI update
- [ ] ♻️ Code refactoring
- [ ] ⚡ Performance improvement

## Related Issues

Fixes #19(issue number)

## Changes Made

Changed the url for Security Advisories from (https://github.com/OWASP-STUDENT-CHAPTER/oss-programs/security/advisories/new) to (https://github.com/OWASP-STUDENT-CHAPTER/oss-programs/security) to prevent 404 but the primary fix requires them to enable the feature in their settings which can only be done by the admin.



## Checklist

- [*] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [*] My changes generate no new warnings
- [ *] I have tested my changes locally

## Screenshots (if applicable)

Add screenshots here.

## Additional Notes

Any additional information or context.
