### PR TITLE
feat: add share button to ProgramCard (#39)

### DIFF
--- a/src/components/ProgramCard.tsx
+++ b/src/components/ProgramCard.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 import { Banknote, CircleDot, Clock, XCircle, ArrowRight } from "lucide-react";
 
 import { BookmarkButton } from "@/components/BookmarkButton";
+import { ShareButton } from "@/components/ShareButton";
 
 interface ProgramCardProps {
     program: ComputedProgram;
@@ -79,7 +80,8 @@ export function ProgramCard({ program, index, matches }: ProgramCardProps) {
                                 <HighlightMatch text={program.name} matches={matches} keyName="name" />
                             </h3>
 
-                            <div className="shrink-0 pt-1">
+                            <div className="shrink-0 pt-1 flex items-center gap-1.5">
+                                <ShareButton slug={program.slug} name={program.name} />
                                 <BookmarkButton slug={program.slug} size="md" />
                             </div>
                         </div>

--- a/src/components/ShareButton.tsx
+++ b/src/components/ShareButton.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState, useRef, useEffect } from "react";
+import { Share2, Check } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface ShareButtonProps {
+    slug: string;
+    name: string;
+}
+
+export function ShareButton({ slug, name }: ShareButtonProps) {
+    const [shared, setShared] = useState(false);
+    const [usedClipboard, setUsedClipboard] = useState(false);
+    const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    useEffect(() => {
+        return () => {
+            if (timerRef.current) clearTimeout(timerRef.current);
+        };
+    }, []);
+
+    const handleShare = async (e: React.MouseEvent) => {
+        e.stopPropagation();
+        e.preventDefault();
+
+        const url = `${window.location.origin}/programs/${slug}`;
+
+        try {
+            if (navigator.share) {
+                await navigator.share({
+                    title: name,
+                    url,
+                });
+                setUsedClipboard(false);
+            } else {
+                await navigator.clipboard.writeText(url);
+                setUsedClipboard(true);
+            }
+
+            if (timerRef.current) clearTimeout(timerRef.current);
+            setShared(true);
+            timerRef.current = setTimeout(() => setShared(false), 2000);
+        } catch (err) {
+            // User cancelled the share dialog — ignore
+            if (err instanceof Error && err.name !== "AbortError") {
+                console.error("Share failed:", err);
+            }
+        }
+    };
+
+    const Icon = shared ? Check : Share2;
+
+    return (
+        <button
+            onClick={handleShare}
+            aria-label={shared ? (usedClipboard ? "Link copied" : "Link shared") : "Share program"}
+            className={cn(
+                "flex items-center justify-center rounded-full transition-all duration-200",
+                "w-9 h-9",
+                shared
+                    ? "bg-black text-white dark:bg-white dark:text-black"
+                    : "bg-muted hover:bg-muted/70 text-muted-foreground"
+            )}
+        >
+            <Icon
+                className={cn(
+                    "w-4 h-4 transition-all duration-200"
+                )}
+            />
+        </button>
+    );
+}


### PR DESCRIPTION
Summary

Adds a dedicated Share icon button to each ProgramCard so users can instantly share a program's direct link.

Closes #39

Changes

New: ShareButton.tsx
- Client component using Share2 and Check icons from lucide-react
- Uses Web Share API (navigator.share) when supported for the native share sheet
- Falls back to clipboard copy (navigator.clipboard.writeText) on unsupported browsers
- Shows brief visual confirmation: icon swaps from Share2 to Check for 2 seconds on success
- Styled identically to the existing BookmarkButton (circular, same colors and sizes)
- Handles AbortError gracefully when user cancels share dialog

Modified: ProgramCard.tsx
- Imported ShareButton
- Placed next to BookmarkButton in the card header with a flex gap wrapper
- Share URL points to /programs/[slug] (the specific program page)

Testing
- next build passes
- Share button renders on every program card
- Clicking share does not navigate to the program detail page (stopPropagation + preventDefault)
- URL copied is in the correct /programs/[slug] format
